### PR TITLE
move test files to _test package namespace

### DIFF
--- a/client/connection_test.go
+++ b/client/connection_test.go
@@ -1,4 +1,4 @@
-package client //nolint: testpackage
+package client_test
 
 import (
 	"bytes"
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aserto-dev/go-aserto/client"
 	"github.com/aserto-dev/header"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -32,7 +33,7 @@ type dialRecorder struct {
 	address     string
 	tlsConf     *tls.Config
 	callerCreds credentials.PerRPCCredentials
-	connection  *Connection
+	connection  *client.Connection
 	dialOptions []grpc.DialOption
 }
 
@@ -41,7 +42,7 @@ func (d *dialRecorder) DialContext(
 	address string,
 	tlsConf *tls.Config,
 	callerCreds credentials.PerRPCCredentials,
-	connection *Connection,
+	connection *client.Connection,
 	options []grpc.DialOption,
 ) (grpc.ClientConnInterface, error) {
 	d.context = ctx
@@ -56,10 +57,10 @@ func (d *dialRecorder) DialContext(
 
 func TestWithAddr(t *testing.T) {
 	recorder := &dialRecorder{}
-	options, err := NewConnectionOptions(WithAddr("address"))
+	options, err := client.NewConnectionOptions(client.WithAddr("address"))
 	assert.NoError(t, err)
 
-	newConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
+	client.InternalNewConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
 
 	assert.Equal(t, "address", recorder.address)
 }
@@ -71,9 +72,9 @@ func TestWithURL(t *testing.T) {
 	svcURL, err := url.Parse(URL)
 	assert.NoError(t, err)
 
-	options, err := NewConnectionOptions(WithURL(svcURL))
+	options, err := client.NewConnectionOptions(client.WithURL(svcURL))
 	assert.NoError(t, err)
-	newConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
+	client.InternalNewConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
 
 	assert.Equal(t, URL, recorder.address)
 }
@@ -82,24 +83,24 @@ func TestAddrAndURL(t *testing.T) {
 	svcURL, err := url.Parse("https://server.com:123")
 	assert.NoError(t, err)
 
-	_, err = NewConnectionOptions(WithAddr("address"), WithURL(svcURL))
+	_, err = client.NewConnectionOptions(client.WithAddr("address"), client.WithURL(svcURL))
 	assert.Error(t, err)
 }
 
 func TestWithInsecure(t *testing.T) {
 	recorder := &dialRecorder{}
-	options, err := NewConnectionOptions(WithInsecure(true))
+	options, err := client.NewConnectionOptions(client.WithInsecure(true))
 	assert.NoError(t, err)
-	newConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
+	client.InternalNewConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
 
 	assert.True(t, recorder.tlsConf.InsecureSkipVerify)
 }
 
 func TestWithTokenAuth(t *testing.T) {
 	recorder := &dialRecorder{}
-	options, err := NewConnectionOptions(WithTokenAuth("<token>"))
+	options, err := client.NewConnectionOptions(client.WithTokenAuth("<token>"))
 	assert.NoError(t, err)
-	newConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
+	client.InternalNewConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
 
 	md, err := recorder.callerCreds.GetRequestMetadata(context.TODO())
 	assert.NoError(t, err)
@@ -111,9 +112,9 @@ func TestWithTokenAuth(t *testing.T) {
 
 func TestWithBearerTokenAuth(t *testing.T) {
 	recorder := &dialRecorder{}
-	options, err := NewConnectionOptions(WithTokenAuth("bearer <token>"))
+	options, err := client.NewConnectionOptions(client.WithTokenAuth("bearer <token>"))
 	assert.NoError(t, err)
-	newConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
+	client.InternalNewConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
 
 	md, err := recorder.callerCreds.GetRequestMetadata(context.TODO())
 	assert.NoError(t, err)
@@ -125,9 +126,9 @@ func TestWithBearerTokenAuth(t *testing.T) {
 
 func TestWithAPIKey(t *testing.T) {
 	recorder := &dialRecorder{}
-	options, err := NewConnectionOptions(WithAPIKeyAuth("<apikey>"))
+	options, err := client.NewConnectionOptions(client.WithAPIKeyAuth("<apikey>"))
 	assert.NoError(t, err)
-	newConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
+	client.InternalNewConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
 
 	md, err := recorder.callerCreds.GetRequestMetadata(context.TODO())
 	assert.NoError(t, err)
@@ -138,20 +139,20 @@ func TestWithAPIKey(t *testing.T) {
 }
 
 func TestTokenAndAPIKey(t *testing.T) {
-	_, err := NewConnectionOptions(WithAPIKeyAuth("<apikey>"), WithTokenAuth("<token>"))
+	_, err := client.NewConnectionOptions(client.WithAPIKeyAuth("<apikey>"), client.WithTokenAuth("<token>"))
 	assert.Error(t, err)
 }
 
 func TestWithTenantID(t *testing.T) {
 	recorder := &dialRecorder{}
-	options, err := NewConnectionOptions(WithTenantID("<tenantid>"))
+	options, err := client.NewConnectionOptions(client.WithTenantID("<tenantid>"))
 	assert.NoError(t, err)
-	newConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
+	client.InternalNewConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
 
 	assert.Equal(t, "<tenantid>", recorder.connection.TenantID)
 
 	ctx := context.TODO()
-	recorder.connection.unary( //nolint: errcheck, dupl
+	recorder.connection.InternalUnary( //nolint: errcheck, dupl
 		ctx,
 		"method",
 		"request",
@@ -173,7 +174,7 @@ func TestWithTenantID(t *testing.T) {
 			return nil
 		})
 
-	recorder.connection.stream( //nolint: errcheck
+	recorder.connection.InternalStream( //nolint: errcheck
 		ctx,
 		nil,
 		recorder.connection.Conn.(*grpc.ClientConn),
@@ -202,14 +203,14 @@ func TestWithTenantID(t *testing.T) {
 
 func TestWithSessionID(t *testing.T) {
 	recorder := &dialRecorder{}
-	options, err := NewConnectionOptions(WithSessionID("<sessionid>"))
+	options, err := client.NewConnectionOptions(client.WithSessionID("<sessionid>"))
 	assert.NoError(t, err)
-	newConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
+	client.InternalNewConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
 
 	assert.Equal(t, "<sessionid>", recorder.connection.SessionID)
 
 	ctx := context.TODO()
-	recorder.connection.unary( //nolint: errcheck, dupl
+	recorder.connection.InternalUnary( //nolint: errcheck, dupl
 		ctx,
 		"method",
 		"request",
@@ -231,7 +232,7 @@ func TestWithSessionID(t *testing.T) {
 			return nil
 		})
 
-	recorder.connection.stream( //nolint: errcheck
+	recorder.connection.InternalStream( //nolint: errcheck
 		ctx,
 		nil,
 		recorder.connection.Conn.(*grpc.ClientConn),
@@ -276,9 +277,9 @@ func TestWithCACertPath(t *testing.T) {
 	assert.NoError(t, err, "Failed to save certificate")
 
 	recorder := &dialRecorder{}
-	options, err := NewConnectionOptions(WithCACertPath(caPath))
+	options, err := client.NewConnectionOptions(client.WithCACertPath(caPath))
 	assert.NoError(t, err)
-	newConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
+	client.InternalNewConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
 
 	inPool, err := subjectInCertPool(recorder.tlsConf.RootCAs, CertSubjectName)
 	if err != nil {
@@ -304,9 +305,9 @@ func TestWithCACertPathAndInsecure(t *testing.T) {
 	assert.NoError(t, err, "Failed to save certificate")
 
 	recorder := &dialRecorder{}
-	options, err := NewConnectionOptions(WithCACertPath(caPath), WithInsecure(true))
+	options, err := client.NewConnectionOptions(client.WithCACertPath(caPath), client.WithInsecure(true))
 	assert.NoError(t, err)
-	newConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
+	client.InternalNewConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
 
 	assert.Nil(t, recorder.tlsConf.RootCAs, "Aserto cert should be nil")
 	assert.True(t, recorder.tlsConf.InsecureSkipVerify)
@@ -316,9 +317,9 @@ func TestWithDialOptions(t *testing.T) {
 	recorder := &dialRecorder{}
 	creds := grpc.WithTransportCredentials(insecure.NewCredentials())
 
-	options, err := NewConnectionOptions(WithDialOptions(creds))
+	options, err := client.NewConnectionOptions(client.WithDialOptions(creds))
 	assert.NoError(t, err)
-	newConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
+	client.InternalNewConnection(context.TODO(), recorder.DialContext, options) //nolint: errcheck
 	assert.Contains(t, recorder.dialOptions, creds)
 }
 

--- a/client/directory/internal/connections_test.go
+++ b/client/directory/internal/connections_test.go
@@ -1,4 +1,4 @@
-package internal //nolint: testpackage
+package internal_test
 
 import (
 	"context"
@@ -7,13 +7,14 @@ import (
 	asserts "github.com/stretchr/testify/assert"
 
 	"github.com/aserto-dev/go-aserto/client"
+	"github.com/aserto-dev/go-aserto/client/directory/internal"
 )
 
 func TestConnections(t *testing.T) {
 	ctx := context.Background()
 
-	counter := &ConnectCounter{}
-	conns := NewConnections()
+	counter := &internal.ConnectCounter{}
+	conns := internal.NewConnections()
 	conns.Connect = counter.Connect
 
 	cfg := &client.Config{Address: "localhost:8282"}

--- a/client/directory/v2/config_test.go
+++ b/client/directory/v2/config_test.go
@@ -1,4 +1,4 @@
-package directory //nolint: testpackage
+package directory_test
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aserto-dev/go-aserto/client"
 	"github.com/aserto-dev/go-aserto/client/directory/internal"
+	"github.com/aserto-dev/go-aserto/client/directory/v2"
 )
 
 const (
@@ -21,7 +22,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	t.Run("base only", func(t *testing.T) {
 		assert := asserts.New(t)
 
-		cfg := Config{}
+		cfg := directory.Config{}
 		if err := json.Unmarshal([]byte(base), &cfg); err != nil {
 			assert.FailNow("failed to unmarshal config", err)
 		}
@@ -36,7 +37,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	t.Run("no base", func(t *testing.T) {
 		assert := asserts.New(t)
 
-		var cfg Config
+		var cfg directory.Config
 		if err := json.Unmarshal([]byte(noBase), &cfg); err != nil {
 			assert.FailNow("failed to unmarshal config", err)
 		}
@@ -53,7 +54,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	t.Run("overrides", func(t *testing.T) {
 		assert := asserts.New(t)
 
-		var cfg Config
+		var cfg directory.Config
 		if err := json.Unmarshal([]byte(overrides), &cfg); err != nil {
 			assert.FailNow("failed to unmarshal config", err)
 		}
@@ -76,11 +77,11 @@ func TestConnect(t *testing.T) {
 
 		conns, counter := mockConns()
 
-		cfg := &Config{
+		cfg := &directory.Config{
 			Config: &client.Config{Address: "localhost:8282"},
 		}
 
-		dir, err := connect(ctx, conns, cfg)
+		dir, err := directory.InternalConnect(ctx, conns, cfg)
 		assert.NoError(err)
 		assert.NotNil(dir)
 		assert.NotNil(dir.Reader)
@@ -95,12 +96,12 @@ func TestConnect(t *testing.T) {
 
 		conns, counter := mockConns()
 
-		cfg := &Config{
+		cfg := &directory.Config{
 			Config: &client.Config{Address: "localhost:1234"},
 			Reader: &client.Config{Address: "localhost:4321"},
 		}
 
-		dir, err := connect(ctx, conns, cfg)
+		dir, err := directory.InternalConnect(ctx, conns, cfg)
 		assert.NoError(err)
 		assert.NotNil(dir)
 		assert.NotNil(dir.Reader)
@@ -115,11 +116,11 @@ func TestConnect(t *testing.T) {
 
 		conns, counter := mockConns()
 
-		cfg := &Config{
+		cfg := &directory.Config{
 			Reader: &client.Config{Address: "localhost:9292"},
 		}
 
-		dir, err := connect(ctx, conns, cfg)
+		dir, err := directory.InternalConnect(ctx, conns, cfg)
 		assert.NoError(err)
 		assert.NotNil(dir)
 		assert.NotNil(dir.Reader)

--- a/client/directory/v2/export_test.go
+++ b/client/directory/v2/export_test.go
@@ -1,0 +1,11 @@
+package directory
+
+import (
+	"context"
+
+	"github.com/aserto-dev/go-aserto/client/directory/internal"
+)
+
+func InternalConnect(ctx context.Context, conns *internal.Connections, cfg *Config) (*Client, error) {
+	return connect(ctx, conns, cfg)
+}

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+func InternalNewConnection(ctx context.Context,
+	dialContext dialer,
+	options *ConnectionOptions,
+) (*Connection, error) {
+	return newConnection(ctx, dialContext, options)
+}
+
+func (c *Connection) InternalUnary(
+	ctx context.Context,
+	method string,
+	req, reply interface{},
+	cc *grpc.ClientConn,
+	invoker grpc.UnaryInvoker,
+	opts ...grpc.CallOption,
+) error {
+	return c.unary(ctx, method, req, reply, cc, invoker, opts...)
+}
+
+func (c *Connection) InternalStream(
+	ctx context.Context,
+	desc *grpc.StreamDesc,
+	cc *grpc.ClientConn,
+	method string,
+	streamer grpc.Streamer,
+	opts ...grpc.CallOption,
+) (grpc.ClientStream, error) {
+	return c.stream(ctx, desc, cc, method, streamer, opts...)
+}

--- a/middleware/grpc/export_test.go
+++ b/middleware/grpc/export_test.go
@@ -1,0 +1,11 @@
+package grpc
+
+import (
+	"context"
+
+	"github.com/aserto-dev/go-authorizer/aserto/authorizer/v2/api"
+)
+
+func (b *IdentityBuilder) InternalBuild(ctx context.Context, req interface{}) *api.IdentityContext {
+	return b.build(ctx, req)
+}

--- a/middleware/grpc/identity_test.go
+++ b/middleware/grpc/identity_test.go
@@ -1,4 +1,4 @@
-package grpc //nolint: testpackage // Testing unexported method .build()
+package grpc_test
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/aserto-dev/go-aserto/middleware/grpc"
 	"github.com/aserto-dev/go-authorizer/aserto/authorizer/v2/api"
 )
 
@@ -28,18 +29,18 @@ func TestTypeAssignment(t *testing.T) {
 	assert.Equal(
 		t,
 		JWT(),
-		(&IdentityBuilder{}).JWT().ID(username).build(context.TODO(), nil),
+		(&grpc.IdentityBuilder{}).JWT().ID(username).InternalBuild(context.TODO(), nil),
 		"Expected JWT identity type",
 	)
 }
 
 func TestAssignmentOverride(t *testing.T) {
-	identity := (&IdentityBuilder{}).JWT().None().build(context.TODO(), nil)
+	identity := (&grpc.IdentityBuilder{}).JWT().None().InternalBuild(context.TODO(), nil)
 
 	assert.Equal(
 		t,
 		Anon(),
-		(&IdentityBuilder{}).JWT().None().build(context.TODO(), nil),
+		(&grpc.IdentityBuilder{}).JWT().None().InternalBuild(context.TODO(), nil),
 		identity.Type,
 		"Expected NONE identity to override JWT",
 	)
@@ -48,8 +49,8 @@ func TestAssignmentOverride(t *testing.T) {
 func TestAssignmentOrder(t *testing.T) {
 	assert.Equal(
 		t,
-		(&IdentityBuilder{}).ID("id").Subject(),
-		(&IdentityBuilder{}).Subject().ID("id"),
+		(&grpc.IdentityBuilder{}).ID("id").Subject(),
+		(&grpc.IdentityBuilder{}).Subject().ID("id"),
 		"Assignment order shouldn't matter",
 	)
 }
@@ -58,13 +59,13 @@ func TestNoneClearsIdentity(t *testing.T) {
 	assert.Equal(
 		t,
 		Anon(),
-		(&IdentityBuilder{}).ID("id").None().build(context.TODO(), nil),
+		(&grpc.IdentityBuilder{}).ID("id").None().InternalBuild(context.TODO(), nil),
 		"WithNone should override previously assigned identity",
 	)
 }
 
 func TestIdentityFromMetadata(t *testing.T) {
-	builder := &IdentityBuilder{}
+	builder := &grpc.IdentityBuilder{}
 	builder.JWT().FromMetadata("authorization")
 
 	md := metadata.New(map[string]string{"authorization": username})
@@ -73,13 +74,13 @@ func TestIdentityFromMetadata(t *testing.T) {
 	assert.Equal(
 		t,
 		JWT(),
-		builder.build(ctx, nil),
+		builder.InternalBuild(ctx, nil),
 		"Identity should be read from context metadata",
 	)
 }
 
 func TestIdentityFromMissingMetadata(t *testing.T) {
-	builder := &IdentityBuilder{}
+	builder := &grpc.IdentityBuilder{}
 	builder.JWT().FromMetadata("authorization")
 
 	md := metadata.New(map[string]string{"wrongKey": username})
@@ -88,19 +89,19 @@ func TestIdentityFromMissingMetadata(t *testing.T) {
 	assert.Equal(
 		t,
 		Anon(),
-		builder.build(ctx, nil),
+		builder.InternalBuild(ctx, nil),
 		"Missing metadata value results in anonymous identity",
 	)
 }
 
 func TestIdentityFromMissingMetadataValue(t *testing.T) {
-	builder := &IdentityBuilder{}
+	builder := &grpc.IdentityBuilder{}
 	builder.JWT().FromMetadata("authorization")
 
 	assert.Equal(
 		t,
 		Anon(),
-		builder.build(context.TODO(), nil),
+		builder.InternalBuild(context.TODO(), nil),
 		"Missing metadata results in anonymous identity",
 	)
 }
@@ -108,7 +109,7 @@ func TestIdentityFromMissingMetadataValue(t *testing.T) {
 type user struct{}
 
 func TestIdentityFromContextValue(t *testing.T) {
-	builder := &IdentityBuilder{}
+	builder := &grpc.IdentityBuilder{}
 	builder.Subject().FromContextValue(user{})
 
 	ctx := context.WithValue(context.TODO(), user{}, "george")
@@ -116,19 +117,19 @@ func TestIdentityFromContextValue(t *testing.T) {
 	assert.Equal(
 		t,
 		SUB(),
-		builder.build(ctx, nil),
+		builder.InternalBuild(ctx, nil),
 		"Identity should be read from context value",
 	)
 }
 
 func TestMissingContextValue(t *testing.T) {
-	builder := &IdentityBuilder{}
+	builder := &grpc.IdentityBuilder{}
 	builder.Subject().FromContextValue(user{})
 
 	assert.Equal(
 		t,
 		Anon(),
-		builder.build(context.TODO(), nil),
+		builder.InternalBuild(context.TODO(), nil),
 		"Missing context value should result in anonymous identity",
 	)
 }

--- a/middleware/http/export_test.go
+++ b/middleware/http/export_test.go
@@ -1,0 +1,5 @@
+package http
+
+func InternalHostnameSegment(hostname string, level int) string {
+	return hostnameSegment(hostname, level)
+}

--- a/middleware/http/identity_test.go
+++ b/middleware/http/identity_test.go
@@ -1,8 +1,9 @@
-package http //nolint: testpackage  // testing unexported logic
+package http_test
 
 import (
 	"testing"
 
+	"github.com/aserto-dev/go-aserto/middleware/http"
 	"gotest.tools/assert"
 )
 
@@ -29,7 +30,7 @@ func TestHostnameSegment(t *testing.T) {
 
 func hostnameSegmentTest(test TestCase) func(*testing.T) {
 	return func(t *testing.T) {
-		actual := hostnameSegment(test.hostname, test.level)
+		actual := http.InternalHostnameSegment(test.hostname, test.level)
 		assert.Equal(t, test.expected, actual)
 	}
 }


### PR DESCRIPTION
This moves the tests into the `_test` package namespace excluding them, from the normal builds/usage, exposing the privates required using the export_test.go pattern to not include them in the regular code either.