### PR TITLE
Eliminate `client.Connection` and add `Close()` method to authorizer and directory clients

### DIFF
--- a/client/authorizer/authorizer.go
+++ b/client/authorizer/authorizer.go
@@ -32,7 +32,12 @@ func New(ctx context.Context, opts ...client.ConnectionOption) (*Client, error) 
 	}, err
 }
 
+// Close closes the underlying connection.
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
 // Connection returns the underlying grpc connection.
-func (c *Client) Connection() grpc.ClientConnInterface {
+func (c *Client) Connection() *grpc.ClientConn {
 	return c.conn.Conn
 }

--- a/client/authorizer/authorizer.go
+++ b/client/authorizer/authorizer.go
@@ -13,7 +13,7 @@ import (
 
 // Client provides access to the Aserto authorization services.
 type Client struct {
-	conn *client.Connection
+	conn *grpc.ClientConn
 
 	// Authorizer provides methods for performing authorization requests.
 	Authorizer authz.AuthorizerClient
@@ -21,14 +21,14 @@ type Client struct {
 
 // NewClient creates a Client with the specified connection options.
 func New(ctx context.Context, opts ...client.ConnectionOption) (*Client, error) {
-	connection, err := client.NewConnection(ctx, opts...)
+	conn, err := client.NewConnection(ctx, opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "create grpc client failed")
 	}
 
 	return &Client{
-		conn:       connection,
-		Authorizer: authz.NewAuthorizerClient(connection.Conn),
+		conn:       conn,
+		Authorizer: authz.NewAuthorizerClient(conn),
 	}, err
 }
 
@@ -38,6 +38,6 @@ func (c *Client) Close() error {
 }
 
 // Connection returns the underlying grpc connection.
-func (c *Client) Connection() *grpc.ClientConn {
-	return c.conn.Conn
+func (c *Client) Connection() grpc.ClientConnInterface {
+	return c.conn
 }

--- a/client/connection.go
+++ b/client/connection.go
@@ -24,25 +24,6 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// Connection represents a gRPC connection with an Aserto tenant ID.
-//
-// The tenant ID is automatically sent to the backend on each request using a ClientInterceptor.
-type Connection struct {
-	// Conn is the underlying gRPC connection to the backend service.
-	Conn *grpc.ClientConn
-
-	// TenantID is the ID of the Aserto tenant making the connection.
-	TenantID string
-
-	// SessionID
-	SessionID string
-}
-
-// Close closes the underlying gRPC connection.
-func (c *Connection) Close() error {
-	return c.Conn.Close()
-}
-
 const defaultTimeout time.Duration = time.Duration(5) * time.Second
 
 /*
@@ -77,7 +58,7 @@ context, the default connection timeout is 5 seconds. For example, to increase t
 		aserto.WithTenantID("<Tenant ID>"),
 	)
 */
-func NewConnection(ctx context.Context, opts ...ConnectionOption) (*Connection, error) {
+func NewConnection(ctx context.Context, opts ...ConnectionOption) (*grpc.ClientConn, error) {
 	options, err := NewConnectionOptions(opts...)
 	if err != nil {
 		return nil, err
@@ -91,7 +72,7 @@ func NewConnection(ctx context.Context, opts ...ConnectionOption) (*Connection, 
 	return Connect(ctx, options)
 }
 
-func Connect(ctx context.Context, options *ConnectionOptions) (*Connection, error) {
+func Connect(ctx context.Context, options *ConnectionOptions) (*grpc.ClientConn, error) {
 	return newConnection(ctx, dialContext, options)
 }
 
@@ -102,7 +83,7 @@ type dialer func(
 	address string,
 	tlsConf *tls.Config,
 	callerCreds credentials.PerRPCCredentials,
-	connection *Connection,
+	tenantID, sessionID string,
 	options []grpc.DialOption,
 ) (*grpc.ClientConn, error)
 
@@ -112,7 +93,7 @@ func dialContext(
 	address string,
 	tlsConf *tls.Config,
 	callerCreds credentials.PerRPCCredentials,
-	connection *Connection,
+	tenantID, sessionID string,
 	options []grpc.DialOption,
 ) (*grpc.ClientConn, error) {
 	if address == "" {
@@ -122,8 +103,8 @@ func dialContext(
 	dialOptions := []grpc.DialOption{
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConf)),
 		grpc.WithBlock(),
-		grpc.WithChainUnaryInterceptor(connection.unary),
-		grpc.WithChainStreamInterceptor(connection.stream),
+		grpc.WithChainUnaryInterceptor(unary(tenantID, sessionID)),
+		grpc.WithChainStreamInterceptor(stream(tenantID, sessionID)),
 	}
 	if callerCreds != nil {
 		dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(callerCreds))
@@ -138,15 +119,10 @@ func dialContext(
 	)
 }
 
-func newConnection(ctx context.Context, dialContext dialer, options *ConnectionOptions) (*Connection, error) {
+func newConnection(ctx context.Context, dialContext dialer, options *ConnectionOptions) (*grpc.ClientConn, error) {
 	tlsConf, err := tlsconf.TLSConfig(options.Insecure, options.CACertPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to setup tls configuration")
-	}
-
-	connection := &Connection{
-		TenantID:  options.TenantID,
-		SessionID: options.SessionID,
 	}
 
 	if _, ok := ctx.Deadline(); !ok {
@@ -164,44 +140,41 @@ func newConnection(ctx context.Context, dialContext dialer, options *ConnectionO
 
 	dialOptions = append(dialOptions, options.DialOptions...)
 
-	conn, err := dialContext(
+	return dialContext(
 		ctx,
 		options.ServerAddress(),
 		tlsConf,
 		options.Creds,
-		connection,
+		options.TenantID,
+		options.SessionID,
 		dialOptions,
 	)
+}
 
-	if err != nil {
-		return nil, err
+func unary(tenantID, sessionID string) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply interface{},
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		return invoker(SetTenantContext(SetSessionContext(ctx, sessionID), tenantID), method, req, reply, cc, opts...)
 	}
-
-	connection.Conn = conn
-
-	return connection, nil
 }
 
-func (c *Connection) unary(
-	ctx context.Context,
-	method string,
-	req, reply interface{},
-	cc *grpc.ClientConn,
-	invoker grpc.UnaryInvoker,
-	opts ...grpc.CallOption,
-) error {
-	return invoker(SetTenantContext(SetSessionContext(ctx, c.SessionID), c.TenantID), method, req, reply, cc, opts...)
-}
-
-func (c *Connection) stream(
-	ctx context.Context,
-	desc *grpc.StreamDesc,
-	cc *grpc.ClientConn,
-	method string,
-	streamer grpc.Streamer,
-	opts ...grpc.CallOption,
-) (grpc.ClientStream, error) {
-	return streamer(SetTenantContext(SetSessionContext(ctx, c.SessionID), c.TenantID), desc, cc, method, opts...)
+func stream(tenantID, sessionID string) grpc.StreamClientInterceptor {
+	return func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		return streamer(SetTenantContext(SetSessionContext(ctx, sessionID), tenantID), desc, cc, method, opts...)
+	}
 }
 
 // SetTenantContext returns a new context with the provided tenant ID embedded as metadata.

--- a/client/connection.go
+++ b/client/connection.go
@@ -29,13 +29,18 @@ import (
 // The tenant ID is automatically sent to the backend on each request using a ClientInterceptor.
 type Connection struct {
 	// Conn is the underlying gRPC connection to the backend service.
-	Conn grpc.ClientConnInterface
+	Conn *grpc.ClientConn
 
 	// TenantID is the ID of the Aserto tenant making the connection.
 	TenantID string
 
 	// SessionID
 	SessionID string
+}
+
+// Close closes the underlying gRPC connection.
+func (c *Connection) Close() error {
+	return c.Conn.Close()
 }
 
 const defaultTimeout time.Duration = time.Duration(5) * time.Second
@@ -99,7 +104,7 @@ type dialer func(
 	callerCreds credentials.PerRPCCredentials,
 	connection *Connection,
 	options []grpc.DialOption,
-) (grpc.ClientConnInterface, error)
+) (*grpc.ClientConn, error)
 
 // dialContext is the default dialer that calls grpc.DialContext to establish a connection.
 func dialContext(
@@ -109,7 +114,7 @@ func dialContext(
 	callerCreds credentials.PerRPCCredentials,
 	connection *Connection,
 	options []grpc.DialOption,
-) (grpc.ClientConnInterface, error) {
+) (*grpc.ClientConn, error) {
 	if address == "" {
 		return nil, errors.Wrap(ErrInvalidOptions, "address not specified")
 	}

--- a/client/connection_test.go
+++ b/client/connection_test.go
@@ -44,7 +44,7 @@ func (d *dialRecorder) DialContext(
 	callerCreds credentials.PerRPCCredentials,
 	connection *client.Connection,
 	options []grpc.DialOption,
-) (grpc.ClientConnInterface, error) {
+) (*grpc.ClientConn, error) {
 	d.context = ctx
 	d.address = address
 	d.tlsConf = tlsConf
@@ -157,7 +157,7 @@ func TestWithTenantID(t *testing.T) {
 		"method",
 		"request",
 		"reply",
-		recorder.connection.Conn.(*grpc.ClientConn),
+		recorder.connection.Conn,
 		func(c context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			md, ok := metadata.FromOutgoingContext(c)
 			assert.True(t, ok)
@@ -177,7 +177,7 @@ func TestWithTenantID(t *testing.T) {
 	recorder.connection.InternalStream( //nolint: errcheck
 		ctx,
 		nil,
-		recorder.connection.Conn.(*grpc.ClientConn),
+		recorder.connection.Conn,
 		"method",
 		func(
 			c context.Context,
@@ -215,7 +215,7 @@ func TestWithSessionID(t *testing.T) {
 		"method",
 		"request",
 		"reply",
-		recorder.connection.Conn.(*grpc.ClientConn),
+		recorder.connection.Conn,
 		func(c context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			md, ok := metadata.FromOutgoingContext(c)
 			assert.True(t, ok)
@@ -235,7 +235,7 @@ func TestWithSessionID(t *testing.T) {
 	recorder.connection.InternalStream( //nolint: errcheck
 		ctx,
 		nil,
-		recorder.connection.Conn.(*grpc.ClientConn),
+		recorder.connection.Conn,
 		"method",
 		func(
 			c context.Context,

--- a/client/directory/internal/connections.go
+++ b/client/directory/internal/connections.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/aserto-dev/go-aserto/client"
 	hs "github.com/mitchellh/hashstructure/v2"
+	"github.com/samber/lo"
+	"google.golang.org/grpc"
 )
 
 type Connections struct {
@@ -47,6 +49,12 @@ func (cb *Connections) Get(ctx context.Context, cfg *client.Config) (*client.Con
 	}
 
 	return conn, nil
+}
+
+func (cb *Connections) AsSlice() []*grpc.ClientConn {
+	return lo.MapToSlice(cb.conns, func(_ uint64, conn *client.Connection) *grpc.ClientConn {
+		return conn.Conn
+	})
 }
 
 // Used for testing.

--- a/client/directory/internal/connections.go
+++ b/client/directory/internal/connections.go
@@ -10,18 +10,18 @@ import (
 )
 
 type Connections struct {
-	conns   map[uint64]*client.Connection
-	Connect func(context.Context, ...client.ConnectionOption) (*client.Connection, error)
+	conns   map[uint64]*grpc.ClientConn
+	Connect func(context.Context, ...client.ConnectionOption) (*grpc.ClientConn, error)
 }
 
 func NewConnections() *Connections {
 	return &Connections{
-		conns:   make(map[uint64]*client.Connection),
+		conns:   make(map[uint64]*grpc.ClientConn),
 		Connect: client.NewConnection,
 	}
 }
 
-func (cb *Connections) Get(ctx context.Context, cfg *client.Config) (*client.Connection, error) {
+func (cb *Connections) Get(ctx context.Context, cfg *client.Config) (*grpc.ClientConn, error) {
 	if cfg == nil {
 		return nil, nil
 	}
@@ -52,9 +52,7 @@ func (cb *Connections) Get(ctx context.Context, cfg *client.Config) (*client.Con
 }
 
 func (cb *Connections) AsSlice() []*grpc.ClientConn {
-	return lo.MapToSlice(cb.conns, func(_ uint64, conn *client.Connection) *grpc.ClientConn {
-		return conn.Conn
-	})
+	return lo.Values(cb.conns)
 }
 
 // Used for testing.
@@ -62,7 +60,7 @@ type ConnectCounter struct {
 	Count int
 }
 
-func (cc *ConnectCounter) Connect(context.Context, ...client.ConnectionOption) (*client.Connection, error) {
+func (cc *ConnectCounter) Connect(context.Context, ...client.ConnectionOption) (*grpc.ClientConn, error) {
 	cc.Count++
-	return &client.Connection{}, nil
+	return &grpc.ClientConn{}, nil
 }

--- a/client/directory/v2/config.go
+++ b/client/directory/v2/config.go
@@ -87,6 +87,7 @@ func connect(ctx context.Context, conns *internal.Connections, cfg *Config) (*Cl
 		Writer:   newClient(writer, dws.NewWriterClient),
 		Importer: newClient(importer, dis.NewImporterClient),
 		Exporter: newClient(exporter, des.NewExporterClient),
+		conns:    conns.AsSlice(),
 	}, nil
 }
 

--- a/client/directory/v2/config.go
+++ b/client/directory/v2/config.go
@@ -100,7 +100,7 @@ func getConnection(
 	ctx context.Context,
 	conns *internal.Connections,
 	cfg, fallback *client.Config,
-) (*client.Connection, error) {
+) (*grpc.ClientConn, error) {
 	if cfg != nil {
 		return conns.Get(ctx, cfg)
 	}
@@ -112,11 +112,11 @@ func getConnection(
 	return nil, nil
 }
 
-func newClient[T any](conn *client.Connection, factory func(conn grpc.ClientConnInterface) T) T {
+func newClient[T any](conn *grpc.ClientConn, factory func(conn grpc.ClientConnInterface) T) T {
 	if conn == nil {
 		var t T
 		return t
 	}
 
-	return factory(conn.Conn)
+	return factory(conn)
 }

--- a/client/directory/v2/directory.go
+++ b/client/directory/v2/directory.go
@@ -42,12 +42,10 @@ func New(ctx context.Context, opts ...client.ConnectionOption) (*Client, error) 
 		options.Address = hosted.HostedDirectoryHostname + hosted.HostedDirectoryGRPCPort
 	}
 
-	connection, err := client.Connect(ctx, options)
+	conn, err := client.Connect(ctx, options)
 	if err != nil {
 		return nil, errors.Wrap(err, "create grpc client failed")
 	}
-
-	conn := connection.Conn
 
 	return &Client{
 		Reader:   drs.NewReaderClient(conn),

--- a/client/directory/v2/directory.go
+++ b/client/directory/v2/directory.go
@@ -9,7 +9,9 @@ import (
 	dis "github.com/aserto-dev/go-directory/aserto/directory/importer/v2"
 	drs "github.com/aserto-dev/go-directory/aserto/directory/reader/v2"
 	dws "github.com/aserto-dev/go-directory/aserto/directory/writer/v2"
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc"
 )
 
 // Client provides access to the Aserto Directory APIs.
@@ -25,6 +27,8 @@ type Client struct {
 
 	// Client for the directory exporter service.
 	Exporter des.ExporterClient
+
+	conns []*grpc.ClientConn
 }
 
 // New returns a new Directory with the specified options.
@@ -43,10 +47,26 @@ func New(ctx context.Context, opts ...client.ConnectionOption) (*Client, error) 
 		return nil, errors.Wrap(err, "create grpc client failed")
 	}
 
+	conn := connection.Conn
+
 	return &Client{
-		Reader:   drs.NewReaderClient(connection.Conn),
-		Writer:   dws.NewWriterClient(connection.Conn),
-		Importer: dis.NewImporterClient(connection.Conn),
-		Exporter: des.NewExporterClient(connection.Conn),
+		Reader:   drs.NewReaderClient(conn),
+		Writer:   dws.NewWriterClient(conn),
+		Importer: dis.NewImporterClient(conn),
+		Exporter: des.NewExporterClient(conn),
+		conns:    []*grpc.ClientConn{conn},
 	}, nil
+}
+
+// Close closes the underlying connections.
+func (c *Client) Close() error {
+	var errs error
+
+	for _, conn := range c.conns {
+		if err := conn.Close(); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+
+	return errs
 }

--- a/client/directory/v3/config.go
+++ b/client/directory/v3/config.go
@@ -97,6 +97,7 @@ func connect(ctx context.Context, conns *internal.Connections, cfg *Config) (*Cl
 		Importer: newClient(importer, dis.NewImporterClient),
 		Exporter: newClient(exporter, des.NewExporterClient),
 		Model:    newClient(model, dms.NewModelClient),
+		conns:    conns.AsSlice(),
 	}, nil
 }
 

--- a/client/directory/v3/config.go
+++ b/client/directory/v3/config.go
@@ -110,7 +110,7 @@ func getConnection(
 	ctx context.Context,
 	conns *internal.Connections,
 	cfg, fallback *client.Config,
-) (*client.Connection, error) {
+) (*grpc.ClientConn, error) {
 	if cfg != nil {
 		return conns.Get(ctx, cfg)
 	}
@@ -122,11 +122,11 @@ func getConnection(
 	return nil, nil
 }
 
-func newClient[T any](conn *client.Connection, factory func(conn grpc.ClientConnInterface) T) T {
+func newClient[T any](conn *grpc.ClientConn, factory func(conn grpc.ClientConnInterface) T) T {
 	if conn == nil {
 		var t T
 		return t
 	}
 
-	return factory(conn.Conn)
+	return factory(conn)
 }

--- a/client/directory/v3/directory.go
+++ b/client/directory/v3/directory.go
@@ -46,12 +46,10 @@ func New(ctx context.Context, opts ...client.ConnectionOption) (*Client, error) 
 		options.Address = hosted.HostedDirectoryHostname + hosted.HostedDirectoryGRPCPort
 	}
 
-	connection, err := client.Connect(ctx, options)
+	conn, err := client.Connect(ctx, options)
 	if err != nil {
 		return nil, errors.Wrap(err, "create grpc client failed")
 	}
-
-	conn := connection.Conn
 
 	return &Client{
 		Reader:   drs.NewReaderClient(conn),

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -9,28 +9,14 @@ import (
 func InternalNewConnection(ctx context.Context,
 	dialContext dialer,
 	options *ConnectionOptions,
-) (*Connection, error) {
+) (*grpc.ClientConn, error) {
 	return newConnection(ctx, dialContext, options)
 }
 
-func (c *Connection) InternalUnary(
-	ctx context.Context,
-	method string,
-	req, reply interface{},
-	cc *grpc.ClientConn,
-	invoker grpc.UnaryInvoker,
-	opts ...grpc.CallOption,
-) error {
-	return c.unary(ctx, method, req, reply, cc, invoker, opts...)
+func InternalUnary(tenantID, sessionID string) grpc.UnaryClientInterceptor {
+	return unary(tenantID, sessionID)
 }
 
-func (c *Connection) InternalStream(
-	ctx context.Context,
-	desc *grpc.StreamDesc,
-	cc *grpc.ClientConn,
-	method string,
-	streamer grpc.Streamer,
-	opts ...grpc.CallOption,
-) (grpc.ClientStream, error) {
-	return c.stream(ctx, desc, cc, method, streamer, opts...)
+func InternalStream(tenantID, sessionID string) grpc.StreamClientInterceptor {
+	return stream(tenantID, sessionID)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aserto-dev/header v0.0.4
 	github.com/gin-gonic/gin v1.8.1
 	github.com/gorilla/mux v1.8.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/lestrrat-go/jwx v1.2.25
 	github.com/magefile/mage v1.15.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
@@ -34,6 +35,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,10 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0 h1:RtRsiaGvWxcwd8y3BiRZxsylPT8hLWZ5SPcfI+3IDNk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0/go.mod h1:TzP6duP4Py2pHLVPPQp42aoYI92+PCrVotyR5e8Vqlk=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
And expose underlying `*grpc.ClientConn`