### PR TITLE
Embed AuthorizerClient in az.Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ import (
 
 ctx := context.Background()
 
-resp, err := azClient.Authorizer.Is(ctx, &authorizer.IsRequest{
+resp, err := azClient.Is(ctx, &authorizer.IsRequest{
 	PolicyContext: &api.PolicyContext{
 		Path:      		"peoplefinder.GET.users.__id",
 		Decisions: 		"allowed",

--- a/az/authorizer.go
+++ b/az/authorizer.go
@@ -11,10 +11,8 @@ import (
 
 // Client provides access to the Aserto authorization services.
 type Client struct {
+	authz.AuthorizerClient
 	conn *grpc.ClientConn
-
-	// Authorizer provides methods for performing authorization requests.
-	Authorizer authz.AuthorizerClient
 }
 
 // NewClient creates a Client with the specified connection options.
@@ -25,8 +23,8 @@ func New(opts ...aserto.ConnectionOption) (*Client, error) {
 	}
 
 	return &Client{
-		conn:       conn,
-		Authorizer: authz.NewAuthorizerClient(conn),
+		AuthorizerClient: authz.NewAuthorizerClient(conn),
+		conn:             conn,
 	}, err
 }
 

--- a/examples/middleware/http/gin/main.go
+++ b/examples/middleware/http/gin/main.go
@@ -24,7 +24,7 @@ func main() {
 	defer azClient.Close()
 
 	mw := ginz.New(
-		azClient.Authorizer,
+		azClient,
 		&middleware.Policy{
 			Name:     "local",
 			Decision: "allowed",

--- a/examples/middleware/http/gorilla/main.go
+++ b/examples/middleware/http/gorilla/main.go
@@ -25,7 +25,7 @@ func main() {
 	defer azClient.Close()
 
 	mw := gorillaz.New(
-		azClient.Authorizer,
+		azClient,
 		&middleware.Policy{
 			Name:     "local",
 			Decision: "allowed",

--- a/middleware/gorillaz/example_test.go
+++ b/middleware/gorillaz/example_test.go
@@ -29,7 +29,7 @@ func Example() {
 
 	// Create HTTP middleware.
 	middleware := mw.New(
-		azClient.Authorizer,
+		azClient,
 		&mw.Policy{
 			Name:     "<Aserto policy Name>",
 			Decision: "<authorization decision (e.g. 'allowed')",

--- a/middleware/httpz/example_test.go
+++ b/middleware/httpz/example_test.go
@@ -29,7 +29,7 @@ func Example() {
 
 	// Create HTTP middleware.
 	middleware := httpz.New(
-		azClient.Authorizer,
+		azClient,
 		&httpz.Policy{
 			Name:     "<Aserto policy Name>",
 			Decision: "<authorization decision (e.g. 'allowed')",


### PR DESCRIPTION
This makes it possible to make authorization calls directly on `az.Client` instead of having to dereference `azClient.Authorizer`. It makes for simpler coding and smoother integration with middleware.

The directory client remains unchanged because it is an amalgam of multiple interfaces (reader, writer, importer, etc.) and we should keep the namespaces distinct.