### PR TITLE
Add WithAllowedMethods and deprecate WithIgnoredMethods

### DIFF
--- a/middleware/ginz/check.go
+++ b/middleware/ginz/check.go
@@ -131,7 +131,7 @@ func (o *CheckOptions) subjectType() string {
 		return o.subj.subjType
 	}
 
-	return "user"
+	return internal.DefaultSubjType
 }
 
 type Check struct {

--- a/middleware/gorillaz/check.go
+++ b/middleware/gorillaz/check.go
@@ -131,7 +131,7 @@ func (o *CheckOptions) subjectType() string {
 		return o.subj.subjType
 	}
 
-	return "user"
+	return internal.DefaultSubjType
 }
 
 type Check struct {

--- a/middleware/grpcz/check.go
+++ b/middleware/grpcz/check.go
@@ -9,7 +9,6 @@ import (
 	ds3 "github.com/aserto-dev/go-directory/aserto/directory/reader/v3"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"github.com/samber/lo"
 	"google.golang.org/grpc"
 )
 
@@ -166,19 +165,23 @@ func WithSubjectMapper(mapper ObjectMapper) CheckOption {
 }
 
 func WithMethodFilter(methods ...string) CheckOption {
+	lookup := internal.NewLookup(methods...)
+
 	return func(o *CheckOptions) {
 		o.filters = append(o.filters, func(ctx context.Context, _ any) bool {
 			method, _ := grpc.Method(ctx)
-			return lo.Contains(methods, method)
+			return lookup.Contains(method)
 		})
 	}
 }
 
 func WithContextValueFilter(ctxKey any, values ...string) CheckOption {
+	lookup := internal.NewLookup(values...)
+
 	return func(o *CheckOptions) {
 		o.filters = append(o.filters, func(ctx context.Context, _ any) bool {
 			value := internal.ValueOrEmpty(ctx, ctxKey)
-			return lo.Contains(values, value)
+			return lookup.Contains(value)
 		})
 	}
 }
@@ -294,5 +297,5 @@ func (c *CheckMiddleware) authorize(ctx context.Context, req interface{}) error 
 }
 
 func relationFromMethod(ctx context.Context, _ any) string {
-	return methodResource(ctx)
+	return permissionFromMethod(ctx)
 }

--- a/middleware/grpcz/check.go
+++ b/middleware/grpcz/check.go
@@ -12,11 +12,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-const (
-	DefaultSubjType = "user"
-	DefaultObjType  = "tenant"
-)
-
 type ObjectMapper func(ctx context.Context, req any) (objType, id string)
 type Filter func(ctx context.Context, req any) bool
 
@@ -63,7 +58,12 @@ func (o *CheckOptions) object(ctx context.Context, req any) (string, string) {
 }
 
 func (o *CheckOptions) subject(ctx context.Context, req any) (string, string) {
-	return o.subj.resolve(ctx, req)
+	subjType, subjID := o.subj.resolve(ctx, req)
+	if subjType == "" {
+		subjType = internal.DefaultSubjType
+	}
+
+	return subjType, subjID
 }
 
 func (o *CheckOptions) relation(ctx context.Context, req any) string {

--- a/middleware/grpcz/interceptor_test.go
+++ b/middleware/grpcz/interceptor_test.go
@@ -47,11 +47,11 @@ func NewTest(t *testing.T, name string, options *testOptions) *TestCase {
 
 func TestAuthorizer(t *testing.T) {
 	tests := []*TestCase{
-		NewTest(
-			t,
-			"authorized decisions should succeed",
-			&testOptions{},
-		),
+		// NewTest(
+		// 	t,
+		// 	"authorized decisions should succeed",
+		// 	&testOptions{},
+		// ),
 		NewTest(
 			t,
 			"unauthorized decisions should err",

--- a/middleware/grpcz/interceptor_test.go
+++ b/middleware/grpcz/interceptor_test.go
@@ -47,11 +47,11 @@ func NewTest(t *testing.T, name string, options *testOptions) *TestCase {
 
 func TestAuthorizer(t *testing.T) {
 	tests := []*TestCase{
-		// NewTest(
-		// 	t,
-		// 	"authorized decisions should succeed",
-		// 	&testOptions{},
-		// ),
+		NewTest(
+			t,
+			"authorized decisions should succeed",
+			&testOptions{},
+		),
 		NewTest(
 			t,
 			"unauthorized decisions should err",

--- a/middleware/grpcz/rebac.go
+++ b/middleware/grpcz/rebac.go
@@ -235,13 +235,9 @@ func (c *RebacMiddleware) subjectType() string {
 		return c.subjType
 	}
 
-	return DefaultSubjType
+	return internal.DefaultSubjType
 }
 
 func (c *RebacMiddleware) objectType() string {
-	if c.objType != "" {
-		return c.objType
-	}
-
-	return DefaultObjType
+	return c.objType
 }

--- a/middleware/grpcz/rebac.go
+++ b/middleware/grpcz/rebac.go
@@ -15,6 +15,8 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+const MaxPermissionLen = 64
+
 type RebacMiddleware struct {
 	policy          *Policy
 	client          AuthorizerClient
@@ -219,7 +221,11 @@ func (c *RebacMiddleware) resourceContext(ctx context.Context, req interface{}) 
 
 func permissionFromMethod(ctx context.Context) string {
 	method, _ := grpc.Method(ctx)
-	path := strings.ToLower(internal.ToPolicyPath(method)[:64])
+
+	path := strings.ToLower(internal.ToPolicyPath(method))
+	if len(path) > MaxPermissionLen {
+		path = path[:MaxPermissionLen]
+	}
 
 	return path
 }

--- a/middleware/httpz/check.go
+++ b/middleware/httpz/check.go
@@ -121,7 +121,7 @@ func (o *CheckOptions) subjectType() string {
 		return o.subj.subjType
 	}
 
-	return "user"
+	return internal.DefaultSubjType
 }
 
 type Check struct {

--- a/middleware/internal/default.go
+++ b/middleware/internal/default.go
@@ -1,0 +1,5 @@
+package internal
+
+const (
+	DefaultSubjType = "user"
+)

--- a/middleware/internal/lookup.go
+++ b/middleware/internal/lookup.go
@@ -1,0 +1,21 @@
+package internal
+
+import "github.com/samber/lo"
+
+type Lookup[T comparable] map[T]struct{}
+
+func NewLookup[T comparable](items ...T) Lookup[T] {
+	return lo.SliceToMap(items, func(item T) (T, struct{}) {
+		return item, struct{}{}
+	})
+}
+
+func (l Lookup[T]) Contains(item T) bool {
+	if l == nil {
+		return false
+	}
+
+	_, ok := l[item]
+
+	return ok
+}


### PR DESCRIPTION
The gRPC middleware's `WithIgnoredMethods` doesn't really take gRPC methods as its input. What it takes is a list of policy paths that shouldn't be evaluated by the authorizer and instead be allowed by the middleware.
This is confusing because:
  a. The paths passed in may not even exist in the policy.
  b. When a `PolicyPathMapper` is attached to the middleware, the path that is used for a given method may not be obvious from reading the config file.
That function is not marked deprecated.

Instead we now have `WithAllowedMethods` that takes a list of gRPC method names as returned by `grpc.Method(ctx)` (e.g. `/aserto.common.info.v1.Config/Get`).