### PR TITLE
Add TLSConfig for managing transport credentials.

### DIFF
--- a/internal/tlsconf/tls_darwin.go
+++ b/internal/tlsconf/tls_darwin.go
@@ -1,45 +1,13 @@
 package tlsconf
 
 import (
-	"crypto/tls"
 	"crypto/x509"
-	"os"
-
-	"github.com/pkg/errors"
 )
 
-func TLSConfig(insecure bool, caCertPath string) (*tls.Config, error) {
-	var (
-		tlsConf  tls.Config
-		certPool *x509.CertPool
-		err      error
-	)
-
-	if insecure {
-		tlsConf.InsecureSkipVerify = true //nolint: gosec
-		return &tlsConf, nil
-	}
-
+func CertPool(caCertPath string) (*x509.CertPool, error) {
 	if caCertPath == "" {
-		certPool, err = x509.SystemCertPool()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get system cert pool")
-		}
-	} else {
-		certPool = x509.NewCertPool()
-		caCertBytes, err := os.ReadFile(caCertPath)
-
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to read ca cert [%s]", caCertPath)
-		}
-
-		if !certPool.AppendCertsFromPEM(caCertBytes) {
-			return nil, errors.Wrapf(err, "failed to append client ca cert [%s]", caCertPath)
-		}
+		return x509.SystemCertPool()
 	}
 
-	tlsConf.RootCAs = certPool
-	tlsConf.MinVersion = tls.VersionTLS12
-
-	return &tlsConf, nil
+	return x509.NewCertPool(), nil
 }

--- a/internal/tlsconf/tls_linux.go
+++ b/internal/tlsconf/tls_linux.go
@@ -1,45 +1,13 @@
 package tlsconf
 
 import (
-	"crypto/tls"
 	"crypto/x509"
-	"os"
-
-	"github.com/pkg/errors"
 )
 
-func TLSConfig(insecure bool, caCertPath string) (*tls.Config, error) {
-	var (
-		tlsConf  tls.Config
-		certPool *x509.CertPool
-		err      error
-	)
-
-	if insecure {
-		tlsConf.InsecureSkipVerify = true //nolint: gosec
-		return &tlsConf, nil
-	}
-
+func CertPool(caCertPath string) (*x509.CertPool, error) {
 	if caCertPath == "" {
-		certPool, err = x509.SystemCertPool()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get system cert pool")
-		}
-	} else {
-		certPool = x509.NewCertPool()
-		caCertBytes, err := os.ReadFile(caCertPath)
-
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to read ca cert [%s]", caCertPath)
-		}
-
-		if !certPool.AppendCertsFromPEM(caCertBytes) {
-			return nil, errors.Wrapf(err, "failed to append client ca cert [%s]", caCertPath)
-		}
+		return x509.SystemCertPool()
 	}
 
-	tlsConf.RootCAs = certPool
-	tlsConf.MinVersion = tls.VersionTLS12
-
-	return &tlsConf, nil
+	return x509.NewCertPool(), nil
 }

--- a/internal/tlsconf/tls_windows.go
+++ b/internal/tlsconf/tls_windows.go
@@ -1,37 +1,15 @@
 package tlsconf
 
 import (
-	"crypto/tls"
 	"crypto/x509"
-	"os"
-
-	"github.com/pkg/errors"
 )
 
-func TLSConfig(insecure bool, caCertPath string) (*tls.Config, error) {
-	var tlsConf tls.Config
+func CertPool(caCertPath string) (*x509.CertPool, error) {
+	var certPool *x509.CertPool
 
-	if insecure {
-		tlsConf.InsecureSkipVerify = true //nolint: gosec
-		return &tlsConf, nil
+	if caCertPath == "" {
+		return certPool, nil
 	}
 
-	if caCertPath != "" {
-		certPool := x509.NewCertPool()
-		caCertBytes, err := os.ReadFile(caCertPath)
-
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to read ca cert [%s]", caCertPath)
-		}
-
-		if !certPool.AppendCertsFromPEM(caCertBytes) {
-			return nil, errors.Wrapf(err, "failed to append client ca cert [%s]", caCertPath)
-		}
-
-		tlsConf.RootCAs = certPool
-	}
-
-	tlsConf.MinVersion = tls.VersionTLS12
-
-	return &tlsConf, nil
+	return x509.NewCertPool(), nil
 }

--- a/option.go
+++ b/option.go
@@ -23,6 +23,15 @@ func WithInsecure(insecure bool) ConnectionOption {
 	}
 }
 
+// WithNoTLS disables transport security. The connection is established in plaintext.
+func WithNoTLS(noTLS bool) ConnectionOption {
+	return func(options *ConnectionOptions) error {
+		options.NoTLS = noTLS
+
+		return nil
+	}
+}
+
 // WithAddr overrides the default authorizer server address.
 //
 // Note: WithAddr and WithURL are mutually exclusive.
@@ -157,14 +166,6 @@ func WithHeader(key, value string) ConnectionOption {
 
 		options.Headers[key] = value
 
-		return nil
-	}
-}
-
-// WithNoTLS disables transport security. The connection is established in plaintext.
-func WithNoTLS(noTLS bool) ConnectionOption {
-	return func(options *ConnectionOptions) error {
-		options.NoTLS = noTLS
 		return nil
 	}
 }

--- a/tls.go
+++ b/tls.go
@@ -1,0 +1,113 @@
+package aserto
+
+import (
+	"crypto/tls"
+	"os"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/aserto-dev/go-aserto/internal/tlsconf"
+)
+
+type NoTLSVerify bool
+
+const (
+	VerifyTLS     = NoTLSVerify(false)
+	SkipVerifyTLS = NoTLSVerify(true)
+)
+
+// TLSConfig contains paths to an X509 certificate's key-pair and CA files.
+// It can be used to create client or server tls.Config or grpc TransportCredentials.
+type TLSConfig struct {
+	Cert string `json:"tls_cert_path"`
+	Key  string `json:"tls_key_path"`
+	CA   string `json:"tls_ca_cert_path"`
+}
+
+func (c *TLSConfig) IsTLS() bool {
+	return c != nil && c.Cert != "" && c.Key != "" && c.CA != ""
+}
+
+func (c *TLSConfig) NoTLS() bool {
+	return !c.IsTLS()
+}
+
+// ServerConfig returns TLS configuration for a server.
+func (c *TLSConfig) ServerConfig() (*tls.Config, error) {
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	if c.NoTLS() {
+		return cfg, nil
+	}
+
+	certificate, err := tls.LoadX509KeyPair(c.Cert, c.Key)
+	if err != nil {
+		return cfg, errors.Wrapf(err, "failed to load gateway certs")
+	}
+
+	cfg.Certificates = []tls.Certificate{certificate}
+
+	return cfg, nil
+}
+
+// ClientConfig returns TLS configuration for a client.
+func (c *TLSConfig) ClientConfig(skipVerify NoTLSVerify) (*tls.Config, error) {
+	conf, err := c.ServerConfig()
+	if err != nil {
+		return &tls.Config{MinVersion: tls.VersionTLS12}, err
+	}
+
+	if skipVerify == SkipVerifyTLS {
+		conf.InsecureSkipVerify = true
+		return conf, nil
+	}
+
+	certPool, err := tlsconf.CertPool(c.CA)
+	if err != nil {
+		return conf, errors.Wrap(err, "failed to create certificate pool")
+	}
+
+	caCertBytes, err := os.ReadFile(c.CA)
+	if err != nil {
+		return conf, errors.Wrapf(err, "failed to read ca cert: %s", c.CA)
+	}
+
+	if !certPool.AppendCertsFromPEM(caCertBytes) {
+		return conf, errors.Wrap(err, "failed to append client ca cert: %s")
+	}
+
+	conf.RootCAs = certPool
+
+	return conf, nil
+}
+
+// ServerCredentials returns transport credentials for a GRPC server.
+func (c *TLSConfig) ServerCredentials() (credentials.TransportCredentials, error) {
+	if c.NoTLS() {
+		return insecure.NewCredentials(), nil
+	}
+
+	tlsConfig, err := c.ServerConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return credentials.NewTLS(tlsConfig), nil
+}
+
+// ClientCredentials returns transport credentials for a GRPC client.
+func (c *TLSConfig) ClientCredentials(skipVerify NoTLSVerify) (credentials.TransportCredentials, error) {
+	if c.NoTLS() {
+		return insecure.NewCredentials(), nil
+	}
+
+	tlsConfig, err := c.ClientConfig(skipVerify)
+	if err != nil {
+		return nil, err
+	}
+
+	return credentials.NewTLS(tlsConfig), nil
+}


### PR DESCRIPTION
This change introduces the `TLSConfig` structure that can be used to construct `tls.Config` and transport credentials for servers and clients.