### PR TITLE
Allow credentials to be sent if `no_tls` is set

### DIFF
--- a/internal/client/credentials.go
+++ b/internal/client/credentials.go
@@ -32,7 +32,7 @@ func (t TokenAuth) GetRequestMetadata(_ context.Context, _ ...string) (map[strin
 }
 
 func (TokenAuth) RequireTransportSecurity() bool {
-	return true
+	return false
 }
 
 // APIKeyAuth API key based authentication.
@@ -55,5 +55,5 @@ func (k *APIKeyAuth) GetRequestMetadata(_ context.Context, _ ...string) (map[str
 }
 
 func (k *APIKeyAuth) RequireTransportSecurity() bool {
-	return true
+	return false
 }


### PR DESCRIPTION
Our `TokenAuth` and `APIKeyAuth` credentials require transport security.
As a result, even when explicitly setting `WithNoTLS(true)` or `no_tls: true` in config, clients are prohibited from sending credentials.
This change lifts that requirement allowing the use of credentials even in plaintext connections.