### PR TITLE
Add NoProxy option to client config

### DIFF
--- a/config.go
+++ b/config.go
@@ -47,6 +47,9 @@ type Config struct {
 	// Disable TLS and use a plaintext connection.
 	NoTLS bool `json:"no_tls"`
 
+	// NoProxy bypasses any configured HTTP proxy.
+	NoProxy bool `json:"no_proxy"`
+
 	// Additional headers to include in requests to the service.
 	Headers map[string]string `json:"headers"`
 

--- a/option.go
+++ b/option.go
@@ -133,6 +133,14 @@ func WithAccountID(accountID string) ConnectionOption {
 	}
 }
 
+// WithNoProxy returns a ConnectionOption that bypasses any configured HTTP proxy.
+func WithNoProxy(noProxy bool) ConnectionOption {
+	return func(options *ConnectionOptions) error {
+		options.NoProxy = noProxy
+		return nil
+	}
+}
+
 // WithChainUnaryInterceptor adds a unary interceptor to grpc dial options.
 func WithChainUnaryInterceptor(mw ...grpc.UnaryClientInterceptor) ConnectionOption {
 	return func(options *ConnectionOptions) error {

--- a/options.go
+++ b/options.go
@@ -82,6 +82,10 @@ func (o *ConnectionOptions) ToDialOptions() ([]grpc.DialOption, error) {
 		opts = append(opts, contextWrapperInterceptor(o.accountContext)...)
 	}
 
+	if o.NoProxy {
+		opts = append(opts, grpc.WithNoProxy())
+	}
+
 	if len(o.Headers) > 0 {
 		opts = append(opts, o.outgoingHeaders()...)
 	}


### PR DESCRIPTION
It causes the gRPC connection to be created using the WithNoProxy dial option, which bypasses any configured HTTP proxy and connects to the server directly.