### PR TITLE
Add az.FromConnection

### DIFF
--- a/az/authorizer.go
+++ b/az/authorizer.go
@@ -28,6 +28,14 @@ func New(opts ...aserto.ConnectionOption) (*Client, error) {
 	}, err
 }
 
+// FromConnection returns a new Client using an existing connection.
+func FromConnection(conn *grpc.ClientConn) *Client {
+	return &Client{
+		AuthorizerClient: authz.NewAuthorizerClient(conn),
+		conn:             conn,
+	}
+}
+
 // Close closes the underlying connection.
 func (c *Client) Close() error {
 	return c.conn.Close()

--- a/ds/v3/directory.go
+++ b/ds/v3/directory.go
@@ -33,7 +33,7 @@ type Client struct {
 	conns []*grpc.ClientConn
 }
 
-// New returns a new Directory with the specified options.
+// New returns a new Client with the specified options.
 func New(opts ...aserto.ConnectionOption) (*Client, error) {
 	options, err := aserto.NewConnectionOptions(opts...)
 	if err != nil {
@@ -59,8 +59,8 @@ func New(opts ...aserto.ConnectionOption) (*Client, error) {
 	}, nil
 }
 
-// New returns a new Directory using an existing connection.
-func FromConnection(conn *grpc.ClientConn) (*Client, error) {
+// FromConnection returns a new Client using an existing connection.
+func FromConnection(conn *grpc.ClientConn) *Client {
 	return &Client{
 		Reader:   drs.NewReaderClient(conn),
 		Writer:   dws.NewWriterClient(conn),
@@ -68,7 +68,7 @@ func FromConnection(conn *grpc.ClientConn) (*Client, error) {
 		Exporter: des.NewExporterClient(conn),
 		Model:    dms.NewModelClient(conn),
 		conns:    []*grpc.ClientConn{conn},
-	}, nil
+	}
 }
 
 // Close closes the underlying connections.


### PR DESCRIPTION
We already have `ds.FromConnection`, and this adds a similar helper for the authorizer client.

This commit also remove the error return value from ds.FromConnection, which is always nil.